### PR TITLE
added configUrl functionality for overriding geonorge urls

### DIFF
--- a/src/functions/apiHelpers.ts
+++ b/src/functions/apiHelpers.ts
@@ -1,14 +1,22 @@
+import { getConfig } from './config';
+
 export const getKartkatalogApiUrl = (environment: string) => {
+    const config = getConfig();
+    if (config.kartkatalogApiUrl) return config.kartkatalogApiUrl;
     const environmentSlug = environment === "dev" || environment === "test" ? environment + "." : "";
     return `https://kartkatalog.${environmentSlug}geonorge.no/api`;
 };
 
 export const getMinSideShortcutApiUrl = (environment: string, shortcutUrl?: string) => {
-    const environmentSlug = environment === "dev" || environment === "test" ? environment + "." : "";
+    const config = getConfig();
     const urlParameterString = shortcutUrl?.length ? `?${new URLSearchParams({ url: shortcutUrl }).toString()}` : "";
+    if (config.minsideUrl) return `${config.minsideUrl}/api/shortcut${urlParameterString}`;
+    const environmentSlug = environment === "dev" || environment === "test" ? environment + "." : "";
     return `https://minside.${environmentSlug}geonorge.no/api/shortcut${urlParameterString}`;
 };
 export const getMinSideShortcutUrl = (environment: string) => {
+    const config = getConfig();
+    if (config.minsideUrl) return `${config.minsideUrl}/shortcuts`;
     const environmentSlug = environment === "dev" || environment === "test" ? environment + "." : "";
     return `https://minside.${environmentSlug}geonorge.no/shortcuts`;
 };
@@ -72,8 +80,10 @@ export const deleteShortcutItem = async (environment: string = "", token: string
 };
 
 export const getGeonorgeMenuUrl = (language: string, environment: string) => {
-    const environmentSlug = environment === "dev" || environment === "test" ? "test." : "";
+    const config = getConfig();
     const selectedLanguageSlug = language === "en" ? "en/" : "";
+    if (config.geonorgeUrl) return `${config.geonorgeUrl}/${selectedLanguageSlug}api/menu/get?omitLinks=1`;
+    const environmentSlug = environment === "dev" || environment === "test" ? "test." : "";
     if (environment === "dev") return `https://dev.geonorge.no/menu.xml`;
     else return `https://www.${environmentSlug}geonorge.no/${selectedLanguageSlug}api/menu/get?omitLinks=1`;
 };

--- a/src/functions/config.ts
+++ b/src/functions/config.ts
@@ -1,0 +1,15 @@
+export interface GeonorgeConfig {
+    kartkatalogUrl?: string;
+    kartkatalogApiUrl?: string;
+    minsideUrl?: string;
+    geonorgeUrl?: string;
+    nedlastingUrl?: string;
+}
+
+let currentConfig: GeonorgeConfig = {};
+
+export const configure = (config: Partial<GeonorgeConfig>) => {
+    currentConfig = { ...currentConfig, ...config };
+};
+
+export const getConfig = (): GeonorgeConfig => currentConfig;

--- a/src/functions/urlHelpers.ts
+++ b/src/functions/urlHelpers.ts
@@ -1,22 +1,34 @@
 // Interfaces
 import { SearchResultsForType } from 'interfaces/search';
+import { getConfig } from './config';
 
 export const getKartkatalogUrl = (environment: string) => {
+    const config = getConfig();
+    if (config.kartkatalogUrl) return config.kartkatalogUrl;
     const environmentSlug = environment === 'dev' || environment === 'test' ? environment + '.' : '';
     return `https://kartkatalog.${environmentSlug}geonorge.no`;
 };
 export const getMinsideUrl = (environment: string) => {
+    const config = getConfig();
+    if (config.minsideUrl) return config.minsideUrl;
     const environmentSlug = environment === 'dev' || environment === 'test' ? environment + '.' : '';
     return `https://minside.${environmentSlug}geonorge.no`;
 };
 
 export const getGeonorgeUrl = (language: string, environment: string) => {
+    const config = getConfig();
+    if (config.geonorgeUrl) {
+        const selectedLanguageSlug = language === 'en' ? 'en/' : '';
+        return `${config.geonorgeUrl}/${selectedLanguageSlug}`;
+    }
     const environmentSlug = environment === 'dev' || environment === 'test' ? 'test.' : '';
     const selectedLanguageSlug = language === 'en' ? 'en/' : '';
     return `https://www.${environmentSlug}geonorge.no/${selectedLanguageSlug}`;
 };
 
 export const getGeonorgeNedlastingUrl = (environment: string) => {
+    const config = getConfig();
+    if (config.nedlastingUrl) return config.nedlastingUrl;
     const environmentSlug = environment === 'dev' || environment === 'test' ? 'test.' : '';
     return `https://nedlasting.${environmentSlug}geonorge.no`;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "./style/fonts.css";
+export { configure } from "./functions/config";
 export * from "./stories/body-text/body-text";
 export * from "./stories/breadcrumb-list/breadcrumb-list";
 export * from "./stories/content-container/content-container";


### PR DESCRIPTION
Alle URL-er som ligger i apiHelpers og urlHelpers kan nå overrides. Kan bruke følgende i for eks. main.jsx i frontend: 

configure({
  kartkatalogUrl: 'https://localhost:5173',
  kartkatalogApiUrl: 'https://localhost:44355/api',
});

Valgte å ikke introdusere en ekstra environment=local, siden det kan ha utilsiktede sideeffekter (har ikke utforsket bruken i webComponents mer), dvs. at man kan spinne opp frontend med environment=dev, men peke på localhost ved bruk av override.